### PR TITLE
Fix input variable name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'auto-cancellation-running-action'
 description: 'Auto Cancellation allows you to only run builds for the latest commits in the queue.'
 inputs:
-  github-token:
+  githubToken:
     description: The GitHub token used to create an authenticated client.
 runs:
   using: 'node12'


### PR DESCRIPTION
Running the action right now causes a warning:
> ##[warning]Unexpected input 'githubToken', valid inputs are ['github-token']

I guess the input should be adjusted to _githubToken_, even though the action still works fine without that. But they may change that at some point. ^^